### PR TITLE
Improve Publishing Workflow for Development

### DIFF
--- a/.github/workflows/python-publish-rec.yml
+++ b/.github/workflows/python-publish-rec.yml
@@ -1,0 +1,35 @@
+name: PyPI Pre-Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [ '3.11' ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Development Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/development.txt
+        pip install -e .
+    - name: Build and Publish to https://test.pypi.org/project/anonypy/
+      env:
+        TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      run: |
+        # builds both sdist and wheel
+        python -m build --no-isolation
+        twine upload --repository testpypi dist/**

--- a/.github/workflows/python-publish-rec.yml
+++ b/.github/workflows/python-publish-rec.yml
@@ -2,8 +2,10 @@ name: PyPI Pre-Release
 
 on:
   workflow_dispatch:
-  release:
-    types: [published, edited]
+  push:
+    tags:
+      - "![0-9]+.[0-9]+.[0-9]+"
+      - "*-rc[0-9]+"
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,35 @@
+name: PyPI Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [ '3.11' ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Development Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/development.txt
+        pip install -e .
+    - name: Build and Publish to https://pypi.org/project/anonypy/
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        # builds both sdist and wheel
+        python -m build --no-isolation
+        twine upload dist/**

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,8 +2,10 @@ name: PyPI Release
 
 on:
   workflow_dispatch:
-  release:
-    types: [published, edited]
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "!*-rc[0-9]+"
 
 jobs:
   deploy:

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,6 @@
 -r release.txt
 build==1.0.3
 wheel==0.41.2
+twine==4.0.2
+setuptools==65.5.0
 pytest==7.4.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ print("processing setup function")
 
 setup(
     name="anonpy",
-    version="0.1.0",
+    version="1.0.0-rc.1",
     license="MIT",
     author="Stefan Greve",
     author_email="greve.stefan@outlook.jp",


### PR DESCRIPTION
- [x] Add workflow file for publishing packages to <https://test.pypi.org>
- [x] Add workflow file for publishing packages to <https://pypi.org>
- [x] #13 
- [x] #38
- [x] #40
- [x] #46 
- [x] Bump version to `1.0.0-rc.1` (in `setup.py`)
- [x] Add workflow tag filter for release candidates