### PR TITLE
Misc Bug Fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,12 @@
         "anonfile",
         "anonfiles",
         "anonpy",
+        "endregion",
         "forcelist",
+        "getproxies",
         "Greve",
         "kanban",
+        "levelname",
         "pipx",
         "tqdm"
     ]

--- a/src/anonpy/__init__.py
+++ b/src/anonpy/__init__.py
@@ -9,5 +9,15 @@ See https://github.com/advanced-systems/anonpy/ for documentation.
 :license: MIT License, see LICENSE for more details
 """
 
+import sys
+
 from .anonpy import AnonPy
+from .internals.metadata import __package__
 from .endpoint import Endpoint
+
+python_major, python_minor = (3, 11)
+
+try:
+    assert sys.version_info >= (python_major, python_minor)
+except AssertionError:
+    raise RuntimeError(f"{__package__} requires {python_major}.{python_minor}+, but found {sys.version}")

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -11,7 +11,7 @@ from .endpoint import Endpoint
 from .internals import LogHandler, LogLevel, RequestHandler, Timeout, __package__, _progressbar_options
 
 
-class AnonPy(RequestHandler, LogHandler):
+class AnonPy(RequestHandler):
     __slots__ = [
         "api",
         "token",

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -81,7 +81,7 @@ class AnonPy(RequestHandler):
 
         self.endpoint = endpoint
         self.enable_logging = enable_logging
-        self.logger = LogHandler(level=LogLevel.DEBUG)
+        self.logger = LogHandler(level=LogLevel.INFO)
 
     def upload(self: Self, path: Union[str, Path], progressbar: bool=False) -> Dict:
         """
@@ -106,7 +106,7 @@ class AnonPy(RequestHandler):
                     files={"file": CallbackIOWrapper(tqdm_handler.update, file_handler, "read")}
                 )
 
-                self.logger.debug("Download: %s", file, hide=not self.enable_logging)
+                self.logger.info("Download: %s", file, hide=not self.enable_logging)
                 return response.json()
 
     def preview(self: Self, resource: str) -> Dict:
@@ -115,7 +115,7 @@ class AnonPy(RequestHandler):
         """
         url = self.endpoint.preview.format(resource)
         response = self._get(url, allow_redirects=True)
-        self.logger.debug("Preview: %s", resource, hide=not self.enable_logging)
+        self.logger.info("Preview: %s", resource, hide=not self.enable_logging)
         return response.json()
 
     def download(
@@ -145,5 +145,5 @@ class AnonPy(RequestHandler):
                         tqdm_handler.update(len(chunk))
                         file_handler.write(chunk)
 
-        self.logger.debug("Upload: %s", url, hide=not self.enable_logging)
+        self.logger.info("Upload: %s", url, hide=not self.enable_logging)
         return preview

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -15,6 +15,7 @@ class AnonPy(RequestHandler):
     __slots__ = [
         "api",
         "token",
+        "credentials",
         "endpoint",
         "enable_logging",
         "logger",

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -81,6 +81,7 @@ class LogHandler:
                 console = StreamHandler(sys.stdout)
                 self.formatter = Formatter(default_layout or layout)
                 console.setFormatter(self.formatter)
+                self.handlers["console"] = console
                 self.__logger.addHandler(console)
                 return self
             case _:

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -14,6 +14,18 @@ from .json_formatter import JsonFormatter
 
 @unique
 class LogLevel(Enum):
+    """
+    ### LogLevel
+    The first log level is the initial default setting when a new logger instance
+    is created. There are six log levels, sorted by assessed importance.
+
+    1. `NOTSET`: default log level on instantiation
+    2. `DEBUG`: detailed status information for debugging purposes
+    3. `INFO`: information for system maintenance
+    4. `WARNING`: requires attention
+    5. `ERROR`: requires action
+    6. `CRITICAL`: requires immediate action
+    """
     NOTSET = 0
     DEBUG = 10
     INFO = 20
@@ -24,14 +36,15 @@ class LogLevel(Enum):
 class LogHandler:
     def __init__(
             self: Self,
-            level: LogLevel,
+            level: Optional[LogLevel]=None,
             path: Optional[Union[str, Path]]=None,
             encoding: str="utf-8"
         ) -> None:
         """
-        Instantiate a new logger object.
+        Instantiate a new logger object. The `level` determines the minimum
+        priority level of messages to log.
         """
-        self.level = level
+        self.level = level or LogLevel.NOTSET
         self.path = Path(path) if path is not None else None
         self.encoding = encoding
         self.formatter: Union[Formatter, JsonFormatter, CsvFormatter] = None
@@ -46,6 +59,13 @@ class LogHandler:
         Set the log file's base path.
         """
         self.path = Path(path)
+        return self
+
+    def with_level(self: Self, level: LogLevel) -> Self:
+        """
+        Set the log level.
+        """
+        self.__logger.setLevel(level.value)
         return self
 
     def add_handler(
@@ -186,7 +206,7 @@ class LogHandler:
         if hide: return
         if not self.handlers: raise TypeError("Logger configured incorrectly: no handler attached this object")
 
-        self.__logger.log(level.value, message, *args)
+        self.__logger.log(level.value, message, *args, stacklevel=3)
 
     def debug(self: Self, message: str, *args: object, hide: bool=False) -> None:
         """

--- a/src/anonpy/providers/pixeldrain.py
+++ b/src/anonpy/providers/pixeldrain.py
@@ -8,6 +8,22 @@ from ..internals import Authorization, RequestHandler
 
 
 class PixelDrain(AnonPy):
+    __slots__ = [
+        "api",
+        "token",
+        "credentials",
+        "endpoint",
+        "enable_logging",
+        "logger",
+        "timeout",
+        "total",
+        "status_forcelist",
+        "backoff_factor",
+        "user_agent",
+        "proxies",
+        "encoding"
+    ]
+
     def __init__(
             self: Self,
             user_agent: str,

--- a/tests/anonpy_test.py
+++ b/tests/anonpy_test.py
@@ -32,28 +32,26 @@ class TestAnonPy(TestCase):
     def test_upload(self: Self, mock_upload: MagicMock) -> None:
         # Arrange
         args = {"path": "foo.txt", "progressbar": False}
-        self.anon.upload = mock_upload
-        self.anon.upload.return_value = MockPixelDrain.get_upload_response(http_code=200)
+        mock_upload.return_value = MockPixelDrain.get_upload_response(http_code=200)
 
         # Act
-        upload = self.anon.upload(**args)
+        upload = mock_upload(**args)
 
         # Assert
-        self.anon.upload.assert_called_once_with(**args)
+        mock_upload.assert_called_once_with(**args)
         self.assertTrue(upload.get("success", False))
 
     @patch("anonpy.AnonPy.preview")
     def test_preview(self: Self, mock_preview: MagicMock) -> None:
         # Arrange
         args = {"resource": MockPixelDrain.id}
-        self.anon.preview = mock_preview
-        self.anon.preview.return_value = MockPixelDrain.get_preview_response(http_code=200)
+        mock_preview.return_value = MockPixelDrain.get_preview_response(http_code=200)
 
         # Act
-        preview = self.anon.preview(**args)
+        preview = mock_preview(**args)
 
         # Assert
-        self.anon.preview.assert_called_once_with(**args)
+        mock_preview.assert_called_once_with(**args)
         self.assertTrue(preview.get("success", False))
         self.assertEqual(preview.get("downloads", -1), 1)
         self.assertEqual(len(preview.keys()), 24)
@@ -69,28 +67,26 @@ class TestAnonPy(TestCase):
             .add_handler(log_file)
 
         mock_preview.side_effect = [self.anon.logger.debug("This shouldn't be logged.", hide=True)]
-
-        self.anon.preview = mock_preview
-        self.anon.preview.return_value = MockPixelDrain.get_preview_response(http_code=200)
+        mock_preview.return_value = MockPixelDrain.get_preview_response(http_code=200)
 
         log_path = self.anon.logger.path.joinpath(log_file)
 
         # Act 1
-        self.anon.preview(**args)
+        mock_preview(**args)
         log_book = self.anon.logger.get_log_history(log_file)
         # Assert 1
-        self.anon.preview.assert_called_once()
+        mock_preview.assert_called_once()
         self.assertTrue(log_path.exists())
         self.assertFalse(len(log_book), msg="Expected log file to be empty because logging is disabled")
 
         # Act 2
         self.anon.enable_logging = True
-        self.anon.preview.side_effect = [self.anon.logger.debug("Hello, %s!", "World")]
-        self.anon.preview(**args)
+        mock_preview.side_effect = [self.anon.logger.debug("Hello, %s!", "World")]
+        mock_preview(**args)
         log_book = self.anon.logger.get_log_history(log_file)
         # Assert 2
         expected = 2
-        self.assertEqual(expected, self.anon.preview.call_count)
+        self.assertEqual(expected, mock_preview.call_count)
         self.assertTrue(len(log_book), msg="Expected log records in log book because is enabled")
 
         # Act 3
@@ -102,13 +98,12 @@ class TestAnonPy(TestCase):
     def test_download(self: Self, mock_download: MagicMock) -> None:
         # Arrange
         args = {"resource": MockPixelDrain.id, "path": Path.home()}
-        self.anon.download = mock_download
-        self.anon.download.return_value = MockPixelDrain.get_download_response(http_code=200)
+        mock_download.return_value = MockPixelDrain.get_download_response(http_code=200)
 
         # Act
-        download = self.anon.download(**args)
+        download = mock_download(**args)
 
         # Assert
-        self.anon.download.assert_called_once_with(**args)
+        mock_download.assert_called_once_with(**args)
         self.assertFalse(download.closed)
         self.assertGreater(len(download.getvalue()), 0)

--- a/tests/log_handler_test.py
+++ b/tests/log_handler_test.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Self, Type
 from unittest import TestCase
+from uuid import uuid4
 
 from anonpy.internals import LogHandler, LogLevel
 
@@ -19,13 +20,14 @@ class TestLogHandler(TestCase):
     @classmethod
     def setUpClass(cls: Type[Self]) -> None:
         cls.logger = LogHandler(path=Path.home(), level=LogLevel.DEBUG)
-        cls.text_log = "text_log.log"
-        cls.csv_log = "csv_log.csv"
-        cls.json_log = "json_log.json"
+        cls.text_log = f"text_log_{uuid4()}.log"
+        cls.csv_log = f"csv_log_{uuid4()}.csv"
+        cls.json_log = f"json_log_{uuid4()}.json"
 
     @classmethod
     def tearDownClass(cls: Type[Self]) -> None:
         cls.logger.shutdown()
+        del cls.logger
 
     def test_text_formatter(self: Self) -> None:
         # Arrange
@@ -33,7 +35,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.text_log)
 
         # Act
-        self.logger.debug("Hello, %s", *args)
+        self.logger.info("Hello, %s!", *args)
         log_book = self.logger.get_log_history(self.text_log)
         record = log_book.pop()
 
@@ -48,7 +50,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.csv_log)
 
         # Act
-        self.logger.debug("Hello, %s", *args)
+        self.logger.info("Hello, %s!", *args)
         log_book = self.logger.get_log_history(self.csv_log)
         record = log_book[0]
 
@@ -64,7 +66,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.json_log, layout=layout)
 
         # Act
-        self.logger.debug("Hello, %s", *args)
+        self.logger.info("Hello, %s!", *args)
         log_book = self.logger.get_log_history(self.json_log)
         record = log_book.pop()
 


### PR DESCRIPTION
## Description
Apply suggested bug fixes from discussion #43 and make the log-related test methods more robust.

## Requirements

- [x] The library should throw an exception eagerly if the user attempts to import this package with an insufficient version
- [x] The AnonPy class inherits from LogHander which isn't necessary, at all
- [x] A test application revealed the following bug that slipped through the unit tests that (console logging), as a consequence of which a TypeError would have been raised