### PR TITLE
Update Python to version 3.12

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,42 @@
+<!--
+================================================================================
+   IMPORTANT NOTES FOR FIRST-TIME CONTRIBUTORS
+================================================================================
+
+1. Make sure to familiarize yourself with the CONTRIBUTING guidelines first
+   before you open a pull request:
+   https://github.com/Advanced-Systems/anonpy/blob/master/CONTRIBUTING.md
+
+2. When in doubt, use the appropriate discussions channels to ask questions:
+   https://github.com/Advanced-Systems/anonpy/discussions/categories/q-a
+
+3. Read and acknowledge our CODE OF CONDUCT at least once:
+   https://github.com/Advanced-Systems/anonpy/blob/master/CODE_OF_CONDUCT.md
+
+Tip: You can open a PR in draft mode to indicate that this submission is a WIP.
+-->
+
 ## Description
 
-<!-- Write a brief summary about your solution -->
+<!--
+    Copy and paste the description from the issue ticket here. If you have
+    deviated from the original problem statement, highlight these changes here.
+-->
 
 ## Requirements
-<!-- Copy and paste the requirements from the issue ticket here -->
+
+<!--
+    Copy and paste the requirements from the issue ticket here.
+-->
 
 - [ ] Task 1
 - [ ] Task 2
 - [ ] Task 3
 
-## Example
 
-```python
-# Optional: Add some usage examples here
-```
+## Remarks
+
+<!--
+    Add some remarks of your own here, if necessary. Feel free to remove this
+    section if none are needed.
+ -->

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,13 +8,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: "3.11"
+      PYTHON: "3.12"
     steps:
     - uses: actions/checkout@master
     - name: Setup Python
       uses: actions/setup-python@master
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Generate a new Code Coverage Report
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.12" ]
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-publish-rec.yml
+++ b/.github/workflows/python-publish-rec.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -39,22 +39,29 @@ usage.
 > [Roadmap](https://github.com/Advanced-Systems/anonpy/milestone/1),
 > which documents the progress path toward the first major release.
 
-Documentation for this project can be found on the GitHub
+Documentation for this project is located on the GitHub
 [Wiki](https://github.com/Advanced-Systems/anonpy/wiki)
-pages.
+page.
 
 ## Installation
 
-> ⚠ It is currently not possible to install this library with `pip` yet.
+> ⚠ It is currently not possible to install this library with `pip` yet, but
+> you may install the release candidate for testing purposes.
 
-This library can be installed with:
+`anonpy` is available on PyPI:
 
 ```powershell
 pip install anonpy
 ```
 
-Alternatively, use the [`pipx`](https://pypa.github.io/pipx/) command if you
-intend to use `anonpy` solely from the command line:
+Release candidates (preview versions) of this library can be installed with:
+
+```powershell
+pip install -i https://test.pypi.org/simple/ anonpy
+```
+
+To ensure a clean and isolated environment for running `anonpy`'s CLI, it is
+recommended to install it with the [`pipx`](https://pypa.github.io/pipx/) command.
 
 ```powershell
 pipx install anonpy
@@ -62,7 +69,7 @@ pipx install anonpy
 
 ## Library
 
-AnonPy can be used to interface with a wide variety of REST services by
+`anonpy` can be used to interface with a wide variety of REST services by
 building a contract with the `Endpoint` class.
 
 ```python
@@ -95,6 +102,9 @@ anonpy --help
 ```
 
 ## Graphical User Interface
+
+> ⚠ This feature is currently not implemented yet, but is expected to be released
+> in version 1.2.0
 
 Launch a graphical user interface for uploading and downloading files:
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
     <a href="https://codecov.io/gh/Advanced-Systems/anonpy" target="_blank" title="Code Coverage">
         <img src="https://codecov.io/gh/Advanced-Systems/anonpy/graph/badge.svg?token=64NLA38DP4">
     </a>
-    <a title="Downloads per Month">
-        <img src="https://img.shields.io/pypi/dm/anonpy">
+    <a href="https://pypistats.org/packages/anonpy" target="_blank" title="Downloads per Month">
+        <img src="https://img.shields.io/pypi/dm/anonpy?label=Downloads">
     </a>
-    <a title="Supported Python Versions">
-        <img src="https://img.shields.io/pypi/pyversions/anonpy">
+    <a href="https://www.python.org/downloads/release/python-3120/" target="_blank" title="Supported Python Version">
+        <img src="https://img.shields.io/pypi/pyversions/anonpy?label=Python">
     </a>
-    <a href="https://github.com/Advanced-Systems/anonpy" title="Release Version">
+    <a href="https://github.com/Advanced-Systems/anonpy" target="_blank" title="Release Version">
         <img src="https://img.shields.io/pypi/v/anonpy?color=blue&label=Release">
     </a>
     <a href="https://github.com/Advanced-Systems/anonpy/blob/master/LICENSE" target="_blank" title="License">

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -2,6 +2,6 @@
 build==1.0.3
 wheel==0.41.2
 twine==4.0.2
-setuptools==65.5.1
+setuptools==68.2.2
 pytest==7.4.2
 pytest-xdist==3.3.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ print("processing setup function")
 
 setup(
     name="anonpy",
-    version="1.0.0-rc.1",
+    version="1.0.0-rc.2",
     license="MIT",
     author="Stefan Greve",
     author_email="greve.stefan@outlook.jp",
@@ -30,7 +30,7 @@ setup(
         "Source Code": "https://github.com/advanced-systems/anonpy",
         "Bug Reports": "https://github.com/advanced-systems/anonpy/issues"
     },
-    python_requires=">=3.11",
+    python_requires=">=3.12",
     install_requires=read_file("requirements/release.txt", split=True),
     extra_requires={
         "dev": read_file("requirements/development.txt", split=True)[1:]
@@ -46,7 +46,7 @@ setup(
         ]
     },
     classifiers=[
-        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/src/anonpy/__init__.py
+++ b/src/anonpy/__init__.py
@@ -15,7 +15,7 @@ from .anonpy import AnonPy
 from .internals.metadata import __package__
 from .endpoint import Endpoint
 
-python_major, python_minor = (3, 11)
+python_major, python_minor = (3, 12)
 
 try:
     assert sys.version_info >= (python_major, python_minor)

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -44,7 +44,7 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
 
         if file is None:
             print("Aborting download: unable to read file name property from preview response", file=sys.stderr)
-            anon.logger.error("Download Error: resource %s responded with %s" % (args.resource, str(preview)))
+            anon.logger.error("Download Error: resource %s responded with %s" % (args.resource, str(preview)), stacklevel=2)
             continue
 
         if check and download_directory.joinpath(file).exists():
@@ -128,10 +128,10 @@ def main() -> None:
     except NotImplementedError:
         parser.print_help()
     except HTTPError as http_error:
-        provider.logger.error("Request failed with HTTP status code %d (%s)" % (http_error.response.status_code, http_error.response.text), stacklevel=1)
+        provider.logger.error("Request failed with HTTP status code %d (%s)" % (http_error.response.status_code, http_error.response.text), stacklevel=2)
         print(http_error.response.text, file=sys.stderr)
     except Exception as exception:
-        provider.logger.critical(exception, stacklevel=1)
+        provider.logger.critical(exception, stacklevel=2)
         print(exception.with_traceback(), file=sys.stderr)
     except:
         print("\n".join([

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -70,7 +70,7 @@ def _start(module_folder: Path, cfg_file: str) -> ArgumentParser:
     parser = build_parser(__package__, __version__, description, epilog)
 
     # Initialize default settings
-    cfg_path = module_folder.joinpath(cfg_file)
+    cfg_path = module_folder / cfg_file
 
     if not cfg_path.exists():
         with ConfigHandler(cfg_path) as config_handler:
@@ -95,7 +95,7 @@ def main() -> None:
     parser = _start(module_folder, cfg_file)
     args = parser.parse_args()
 
-    config = ConfigHandler(getattr(args, "config", module_folder.joinpath(cfg_file)))
+    config = ConfigHandler(getattr(args, "config", module_folder / cfg_file))
     config.read()
 
     kwargs = {
@@ -128,10 +128,11 @@ def main() -> None:
     except NotImplementedError:
         parser.print_help()
     except HTTPError as http_error:
+        provider.logger.error("Request failed with HTTP status code %d (%s)" % (http_error.response.status_code, http_error.response.text))
         print(http_error.response.text, file=sys.stderr)
     except Exception as exception:
-        print(exception.with_traceback())
-        print(exception, file=sys.stderr)
+        provider.logger.critical(exception)
+        print(exception.with_traceback(), file=sys.stderr)
     except:
         print("\n".join([
             "An unhandled exception was thrown. The log file may give you more",

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -128,10 +128,10 @@ def main() -> None:
     except NotImplementedError:
         parser.print_help()
     except HTTPError as http_error:
-        provider.logger.error("Request failed with HTTP status code %d (%s)" % (http_error.response.status_code, http_error.response.text))
+        provider.logger.error("Request failed with HTTP status code %d (%s)" % (http_error.response.status_code, http_error.response.text), stacklevel=1)
         print(http_error.response.text, file=sys.stderr)
     except Exception as exception:
-        provider.logger.critical(exception)
+        provider.logger.critical(exception, stacklevel=1)
         print(exception.with_traceback(), file=sys.stderr)
     except:
         print("\n".join([

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -106,7 +106,7 @@ class AnonPy(RequestHandler):
                     files={"file": CallbackIOWrapper(tqdm_handler.update, file_handler, "read")}
                 )
 
-                self.logger.info("Download: %s", file, hide=not self.enable_logging)
+                self.logger.info("Download: %s", file, hide=not self.enable_logging, stacklevel=2)
                 return response.json()
 
     def preview(self: Self, resource: str) -> Dict:
@@ -115,7 +115,7 @@ class AnonPy(RequestHandler):
         """
         url = self.endpoint.preview.format(resource)
         response = self._get(url, allow_redirects=True)
-        self.logger.info("Preview: %s", resource, hide=not self.enable_logging)
+        self.logger.info("Preview: %s", resource, hide=not self.enable_logging, stacklevel=2)
         return response.json()
 
     def download(
@@ -145,5 +145,5 @@ class AnonPy(RequestHandler):
                         tqdm_handler.update(len(chunk))
                         file_handler.write(chunk)
 
-        self.logger.info("Upload: %s", url, hide=not self.enable_logging)
+        self.logger.info("Upload: %s", url, hide=not self.enable_logging, stacklevel=2)
         return preview

--- a/src/anonpy/internals/csv_formatter.py
+++ b/src/anonpy/internals/csv_formatter.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 from logging import Formatter, LogRecord
-from typing import Dict, Optional, Self
+from typing import Dict, Optional, Self, override
+
 
 class CsvFormatter(Formatter):
     def __init__(
@@ -18,12 +19,14 @@ class CsvFormatter(Formatter):
         self.default_msec_format = msec_format
         self.datefmt = None
 
+    @override
     def usesTime(self) -> bool:
         """
         Check if the format uses the creation time of the record.
         """
         return "asctime" in self.fmt_dict.values()
 
+    @override
     def formatMessage(self, record: LogRecord) -> str:
         """
         Return the specified record as CSV.
@@ -36,7 +39,7 @@ class CsvFormatter(Formatter):
             for fmt_key, fmt_val in self.fmt_dict.items()
         ])
 
-
+    @override
     def format(self: Self, record: LogRecord) -> str:
         """
         Format the specified record as CSV.

--- a/src/anonpy/internals/json_formatter.py
+++ b/src/anonpy/internals/json_formatter.py
@@ -2,7 +2,7 @@
 
 import json
 from logging import Formatter, LogRecord
-from typing import Dict, Optional, Self
+from typing import Dict, Optional, Self, override
 
 
 class JsonFormatter(Formatter):
@@ -19,18 +19,21 @@ class JsonFormatter(Formatter):
         self.default_msec_format = msec_format
         self.datefmt = None
 
+    @override
     def usesTime(self) -> bool:
         """
         Check if the format uses the creation time of the record.
         """
         return "asctime" in self.fmt_dict.values()
 
+    @override
     def formatMessage(self: Self, record: LogRecord) -> Dict:
         """
         Return the specified record as JSON.
         """
         return {fmt_key: record.__dict__[fmt_val] for fmt_key, fmt_val in self.fmt_dict.items()}
 
+    @override
     def format(self: Self, record: LogRecord) -> Dict:
         """
         Format the specified record as JSON.

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -6,7 +6,7 @@ import sys
 from enum import Enum, unique
 from logging import FileHandler, Formatter, StreamHandler, getLogger
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Self, Union
+from typing import Any, Dict, List, Mapping, Optional, Self, TypedDict, Union, Unpack
 
 from .csv_formatter import CsvFormatter
 from .json_formatter import JsonFormatter
@@ -32,6 +32,13 @@ class LogLevel(Enum):
     WARNING = 30
     ERROR = 40
     CRITICAL = 50
+
+
+class LogArgs(TypedDict):
+    exc_info: Optional[BaseException]
+    stack_info: bool
+    stacklevel: int
+    extra: Optional[Mapping[str, object]]
 
 class LogHandler:
     def __init__(
@@ -197,7 +204,7 @@ class LogHandler:
             message: str,
             *args: object,
             hide: bool=False,
-            **kwargs: object
+            **kwargs: Unpack[LogArgs]
         ) -> None:
         """
         Log `message % args` with severity `level`.
@@ -212,31 +219,31 @@ class LogHandler:
 
         self.__logger.log(level.value, message, *args, **kwargs)
 
-    def debug(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
+    def debug(self: Self, message: str, *args: object, hide: bool=False, **kwargs: Unpack[LogArgs]) -> None:
         """
         Log `message % args` with severity `LogLevel.DEBUG`.
         """
         self.__log(LogLevel.DEBUG, message, *args, hide=hide, **kwargs)
 
-    def info(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
+    def info(self: Self, message: str, *args: object, hide: bool=False, **kwargs: Unpack[LogArgs]) -> None:
         """
         Log `message % args` with severity `LogLevel.INFO`.
         """
         self.__log(LogLevel.INFO, message, *args, hide=hide, **kwargs)
 
-    def warning(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
+    def warning(self: Self, message: str, *args: object, hide: bool=False, **kwargs: Unpack[LogArgs]) -> None:
         """
         Log `message % args` with severity `LogLevel.WARNING`.
         """
         self.__log(LogLevel.WARNING, message, *args, hide=hide, **kwargs)
 
-    def error(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
+    def error(self: Self, message: str, *args: object, hide: bool=False, **kwargs: Unpack[LogArgs]) -> None:
         """
         Log `message % args` with severity `LogLevel.ERROR`.
         """
         self.__log(LogLevel.ERROR, message, *args, hide=hide, **kwargs)
 
-    def critical(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
+    def critical(self: Self, message: str, *args: object, hide: bool=False, **kwargs: Unpack[LogArgs]) -> None:
         """
         Log `message % args` with severity `LogLevel.CRITICAL`.
         """

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -40,6 +40,7 @@ class LogArgs(TypedDict):
     stacklevel: int
     extra: Optional[Mapping[str, object]]
 
+
 class LogHandler:
     def __init__(
             self: Self,
@@ -215,7 +216,7 @@ class LogHandler:
         if not self.handlers: raise TypeError("Logger configured incorrectly: no handler attached to this object")
 
         # Add an offset to reset the stacklevel at the calling function
-        kwargs["stacklevel"] = kwargs.get("stacklevel", 2) + 2
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 2
 
         self.__logger.log(level.value, message, *args, **kwargs)
 

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -48,7 +48,8 @@ class LogHandler:
         self.path = Path(path) if path is not None else None
         self.encoding = encoding
         self.formatter: Union[Formatter, JsonFormatter, CsvFormatter] = None
-        # The file name (including extension) is used as a key
+        # The file name (including extension) is used as a key for file logs,
+        # but "console" for stdout
         self.handlers: Dict[str, FileHandler] = {}
 
         self.__logger = getLogger(__name__)
@@ -182,15 +183,15 @@ class LogHandler:
                 handler.flush()
                 handler.close()
             except (OSError, ValueError):
-                # Ignore errors which might be caused because handlers have been
-                # closed but references to them are still around at application exit.
+                # Ignore errors which might be caused by closed handlers that still
+                # have references to them around at application exit
                 pass
             finally:
                 handler.release()
 
     #region log utilities
 
-    def log(
+    def __log(
             self: Self,
             level: LogLevel,
             message: str,
@@ -204,11 +205,10 @@ class LogHandler:
         Raise a `TypeError` exception if the logger is configured incorrectly.
         """
         if hide: return
-        if not self.handlers: raise TypeError("Logger configured incorrectly: no handler attached this object")
+        if not self.handlers: raise TypeError("Logger configured incorrectly: no handler attached to this object")
 
-        # Use a stacklevel of 4 to log the calling method from debug, info, etc.
-        if kwargs.get("stacklevel") is None:
-            kwargs["stacklevel"] = 4
+        # Add an offset to reset the stacklevel at the calling function
+        kwargs["stacklevel"] = kwargs.get("stacklevel", 2) + 2
 
         self.__logger.log(level.value, message, *args, **kwargs)
 
@@ -216,30 +216,30 @@ class LogHandler:
         """
         Log `message % args` with severity `LogLevel.DEBUG`.
         """
-        self.log(LogLevel.DEBUG, message, *args, hide=hide, **kwargs)
+        self.__log(LogLevel.DEBUG, message, *args, hide=hide, **kwargs)
 
     def info(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
         """
         Log `message % args` with severity `LogLevel.INFO`.
         """
-        self.log(LogLevel.INFO, message, *args, hide=hide, **kwargs)
+        self.__log(LogLevel.INFO, message, *args, hide=hide, **kwargs)
 
     def warning(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
         """
         Log `message % args` with severity `LogLevel.WARNING`.
         """
-        self.log(LogLevel.WARNING, message, *args, hide=hide, **kwargs)
+        self.__log(LogLevel.WARNING, message, *args, hide=hide, **kwargs)
 
     def error(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
         """
         Log `message % args` with severity `LogLevel.ERROR`.
         """
-        self.log(LogLevel.ERROR, message, *args, hide=hide, **kwargs)
+        self.__log(LogLevel.ERROR, message, *args, hide=hide, **kwargs)
 
     def critical(self: Self, message: str, *args: object, hide: bool=False, **kwargs: object) -> None:
         """
         Log `message % args` with severity `LogLevel.CRITICAL`.
         """
-        self.log(LogLevel.CRITICAL, message, *args, hide=hide, **kwargs)
+        self.__log(LogLevel.CRITICAL, message, *args, hide=hide, **kwargs)
 
     #endregion

--- a/tests/anonpy_test.py
+++ b/tests/anonpy_test.py
@@ -70,7 +70,7 @@ class TestAnonPy(TestCase):
             .with_level(LogLevel.DEBUG) \
             .add_handler(log_file)
 
-        mock_preview.side_effect = [self.anon.logger.info("This shouldn't be logged.", hide=True, stacklevel=3)]
+        mock_preview.side_effect = [self.anon.logger.info("This shouldn't be logged.", hide=True, stacklevel=1)]
         mock_preview.return_value = MockPixelDrain.get_preview_response(http_code=200)
 
         log_path = self.anon.logger.path.joinpath(log_file)
@@ -85,7 +85,7 @@ class TestAnonPy(TestCase):
 
         # Act 2
         self.anon.enable_logging = True
-        mock_preview.side_effect = [self.anon.logger.info("Hello, %s!", "World", stacklevel=3)]
+        mock_preview.side_effect = [self.anon.logger.info("Hello, %s!", "World", stacklevel=1)]
         self.anon.logger.debug("Announce my loyalty to the emperor!")
         mock_preview(**args)
         log_book = self.anon.logger.get_log_history(log_file)

--- a/tests/anonpy_test.py
+++ b/tests/anonpy_test.py
@@ -70,7 +70,7 @@ class TestAnonPy(TestCase):
             .with_level(LogLevel.DEBUG) \
             .add_handler(log_file)
 
-        mock_preview.side_effect = [self.anon.logger.info("This shouldn't be logged.", hide=True, stacklevel=1)]
+        mock_preview.side_effect = [self.anon.logger.info("This shouldn't be logged.", hide=True)]
         mock_preview.return_value = MockPixelDrain.get_preview_response(http_code=200)
 
         log_path = self.anon.logger.path.joinpath(log_file)
@@ -85,7 +85,7 @@ class TestAnonPy(TestCase):
 
         # Act 2
         self.anon.enable_logging = True
-        mock_preview.side_effect = [self.anon.logger.info("Hello, %s!", "World", stacklevel=1)]
+        mock_preview.side_effect = [self.anon.logger.info("Hello, %s!", "World")]
         self.anon.logger.debug("Announce my loyalty to the emperor!")
         mock_preview(**args)
         log_book = self.anon.logger.get_log_history(log_file)

--- a/tests/log_handler_test.py
+++ b/tests/log_handler_test.py
@@ -35,7 +35,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.text_log)
 
         # Act
-        self.logger.info("Hello, %s!", *args, stacklevel=1)
+        self.logger.info("Hello, %s!", *args)
         log_book = self.logger.get_log_history(self.text_log)
         record = log_book.pop()
 
@@ -50,7 +50,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.csv_log)
 
         # Act
-        self.logger.info("Hello, %s!", *args, stacklevel=1)
+        self.logger.info("Hello, %s!", *args)
         log_book = self.logger.get_log_history(self.csv_log)
         record = log_book[0]
 
@@ -66,7 +66,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.json_log, layout=layout)
 
         # Act
-        self.logger.info("Hello, %s!", *args, stacklevel=1)
+        self.logger.info("Hello, %s!", *args)
         log_book = self.logger.get_log_history(self.json_log)
         record = log_book.pop()
 

--- a/tests/log_handler_test.py
+++ b/tests/log_handler_test.py
@@ -35,7 +35,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.text_log)
 
         # Act
-        self.logger.info("Hello, %s!", *args, stacklevel=3)
+        self.logger.info("Hello, %s!", *args, stacklevel=1)
         log_book = self.logger.get_log_history(self.text_log)
         record = log_book.pop()
 
@@ -50,7 +50,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.csv_log)
 
         # Act
-        self.logger.info("Hello, %s!", *args, stacklevel=3)
+        self.logger.info("Hello, %s!", *args, stacklevel=1)
         log_book = self.logger.get_log_history(self.csv_log)
         record = log_book[0]
 
@@ -66,7 +66,7 @@ class TestLogHandler(TestCase):
         self.logger.add_handler(self.json_log, layout=layout)
 
         # Act
-        self.logger.info("Hello, %s!", *args, stacklevel=3)
+        self.logger.info("Hello, %s!", *args, stacklevel=1)
         log_book = self.logger.get_log_history(self.json_log)
         record = log_book.pop()
 


### PR DESCRIPTION
## Description

Update the minimum version requirements from Python `3.11` to `3.12`.

## Requirements

- [x] Update Python
- [x] Update branch protection rules (make runs against `3.12` mandatory, lift `3.11` rules)

Make use of improved type annotation, in particular:
- [x] `@override` [[PEP 698](https://docs.python.org/3.12/whatsnew/3.12.html#whatsnew312-pep698)]
- [x] `TypedDict` [[PEP 692](https://docs.python.org/3.12/whatsnew/3.12.html#whatsnew312-pep692)]
- [x] `type` aliases [[PEP 695](https://docs.python.org/3/whatsnew/3.12.html#whatsnew312-pep695)]
- [x] Update docs
- [x] Update `README.md`
