### PR TITLE
CLI Extension

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,13 +10,15 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**Steps To Reproduce**
 
 Add a minimal, reproducible example to describe your problem.
 
 ```python
 # your code goes here
 ```
+
+<!-- see also: https://stackoverflow.com/help/minimal-reproducible-example -->
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -25,9 +27,23 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Additional Information**
-- Module Version: `<version>` 
-- Python Version: `<version>`
-- Operating System: `<name>`
+| OS Name    | OS Version | Build Number   | Python Version | Lib Version |
+|:----------:|:----------:|:--------------:|:--------------:|:-----------:|
+| `REDACTED` | `REDACTED` | `REDACTED`     | `REDACTED`     | `REDACTED`  |
+
+<!--
+================================================================================
+
+You can use the following command to retrieve the build number of your OS:
+
+WINDOWS
+Get-CimInstance -ClassName Win32_OperatingSystem | select Version, BuildNumber
+
+LINUX
+lsb_release -a
+
+================================================================================
+ -->
 
 **Additional context**
 Add any other context about the problem here.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "getproxies",
         "Greve",
         "kanban",
+        "keepends",
         "levelname",
         "pipx",
         "tqdm",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
         "levelname",
         "pipx",
         "tqdm",
+        "tracebacks",
         "urandom"
     ]
 }

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,3 +1,4 @@
 cryptography==41.0.4
 requests==2.31.0
 tqdm==4.66.1
+rich==13.6.0

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,4 +1,3 @@
 cryptography==41.0.4
 requests==2.31.0
-tqdm==4.66.1
 rich==13.6.0

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -122,11 +122,10 @@ def upload(anon: AnonPy, args: Namespace, settings: EvalConfig) -> None:
 
     for file in args.file:
         upload = anon.upload(file, enable_progressbar=client["verbose"])
-        url = upload["url"]
-        anon.logger.info("Uploaded %s to %s" % (file, url))
-        console.print(f"URL={url}")
+        anon.logger.info("Uploaded %s to %s" % (file, upload.url))
+        console.print(f"URL={upload.url}")
 
-        if args.clip: copy_to_clipboard(url)
+        if args.clip: copy_to_clipboard(upload.url)
 
         if not client["verbose"]: continue
         algorithm: HashAlgorithm = security["hash"]

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -112,6 +112,9 @@ def main() -> None:
         .with_level(LogLevel(config.get_option("client", "log_level"))) \
         .add_handler(log_file)
 
+    if args.gui:
+        raise NotImplementedError("This feature is not implemented yet, see also: https://github.com/Advanced-Systems/anonpy/discussions/11")
+
     try:
         match args.command:
             case "preview":

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -172,12 +172,13 @@ def main() -> None:
             case "download":
                 download(provider, args, config)
             case _:
-                raise NotImplementedError()
+                # argparse prints the help manual and exits if there are any
+                # errors on parsing, so there's no need to handle this case
+                # here as it will accomplish nothing
+                pass
 
     except KeyboardInterrupt:
         pass
-    except NotImplementedError:
-        parser.print_help()
     except HTTPError as http_error:
         provider.logger.error("ERROR: Request failed with HTTP status code %d (%s)" % (http_error.response.status_code, http_error.response.text), stacklevel=2)
         console.print(http_error.response.text, style="bold red")

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -35,7 +35,7 @@ def upload(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
 def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
     download_directory = Path(getattr(args, "path", config.get_option("client", "download_directory")))
     verbose = args.verbose or config.get_option("client", "verbose")
-    check = args.check or config.get_option("client", "check")
+    force = args.force or config.get_option("client", "force")
 
     for resource in (args.resource or read_file(args.batch_file)):
         preview = anon.preview(resource)
@@ -46,7 +46,7 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
             anon.logger.error("Download Error: resource %s responded with %s" % (args.resource, str(preview)), stacklevel=2)
             continue
 
-        if check and download_directory.joinpath(file).exists():
+        if not force and download_directory.joinpath(file).exists():
             print(f"WARNING: The file {str(file)!r} already exists in {str(download_directory)!r}.")
             prompt = input("Proceed with download? [Y/n] ")
             if not str2bool(prompt): continue
@@ -81,7 +81,7 @@ def _start(module_folder: Path, cfg_file: str) -> ArgumentParser:
                 "enable_logging": False,
                 "log_level": LogLevel.INFO.value,
                 "verbose": True,
-                "check": True,
+                "force": False,
             })
 
             config_handler.add_section("server", settings={

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -5,6 +5,7 @@ import json
 import subprocess
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 from colorama import Fore, Style, deinit, just_fix_windows_console
 from requests.exceptions import HTTPError
@@ -18,6 +19,8 @@ from .security import MD5, Checksum
 
 #region helpers
 
+type EvalConfig = Dict[str, Dict[str, Optional[Any]]]
+
 def print_diff(a: str, b: str) -> None:
         diff = difflib.ndiff(
             f"{a}\n".splitlines(keepends=True),
@@ -29,7 +32,10 @@ def print_diff(a: str, b: str) -> None:
 def copy_to_clipboard(text: str) -> None:
     subprocess.run("clip", input=text, check=True, encoding="utf-8")
 
-def init_settings(cfg_path: Path) -> None:
+def init_config(cfg_path: Path) -> None:
+    """
+    Create a new configuration file by force, potentially overwriting existing data.
+    """
     with ConfigHandler(cfg_path) as config_handler:
         config_handler.add_section("client", settings={
             "download_directory": Path("~/downloads").expanduser(),
@@ -49,38 +55,67 @@ def init_settings(cfg_path: Path) -> None:
             "preview": "/file/{}/info"
         })
 
+def eval_config(args: Namespace, config: ConfigHandler) -> EvalConfig:
+    """
+    Return a dictionary of config values, giving preference to command line arguments.
+    Some values have a fallback in case neither `args` nor `config` provide a value,
+    if `None` is not acceptable.
+    """
+    settings = {
+        "client": {
+            "download_directory": Path(getattr(args, "path", config.get_option("client", "download_directory", default=Path.cwd()))),
+            "token": getattr(args, "token", config.get_option("client", "token")),
+            "user_agent": getattr(args, "user_agent", config.get_option("client", "user_agent", default=RequestHandler.build_user_agent(__package__, __version__))),
+            "proxies": getattr(args, "proxies", config.get_option("client", "proxies")),
+            "enable_logging": getattr(args, "logging", config.get_option("client", "enable_logging")),
+            "log_level": config.get_option("client", "log_level"),
+            "verbose": getattr(args, "verbose", config.get_option("client", "verbose")),
+            "force": getattr(args, "force", config.get_option("client", "force")),
+        },
+        "server": {
+            "api": config.get_option("server", "api"),
+            "upload": config.get_option("server", "upload"),
+            "download": config.get_option("server", "download"),
+            "preview": config.get_option("server", "preview"),
+        }
+    }
+
+    settings["object"] = {
+        "endpoint": Endpoint(settings["server"]["upload"], settings["server"]["download"], settings["server"]["preview"]),
+    }
+
+    return settings
+
 #endregion
 
 #region commands
 
-def preview(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
-    verbose = args.verbose or config.get_option("client", "verbose")
+def preview(anon: AnonPy, args: Namespace, settings: EvalConfig) -> None:
+    client = settings["client"]
 
     for resource in args.resource:
         with console.status("fetching data...") as _:
             preview = anon.preview(resource)
-            console.print(JSON(json.dumps(preview)) if verbose else ",".join(preview.values()))
+            console.print(JSON(json.dumps(preview)) if client["verbose"] else ",".join(preview.values()))
 
-def upload(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
-    verbose = args.verbose or config.get_option("client", "verbose")
+def upload(anon: AnonPy, args: Namespace, settings: EvalConfig) -> None:
+    client = settings["client"]
 
     for file in args.file:
-        upload = anon.upload(file, enable_progressbar=verbose)
+        upload = anon.upload(file, enable_progressbar=client["verbose"])
         url = upload["url"]
         anon.logger.info("Uploaded %s to %s" % (file, url))
         console.print(f"URL={url}")
 
         if args.clip: copy_to_clipboard(url)
 
-        if not verbose: continue
+        if not client["verbose"]: continue
         computed_hash = Checksum.compute(path=file, algorithm=MD5)
         checksum = Checksum.hash2string(computed_hash)
         console.print(f"MD5=[bold blue]{checksum}[/]")
 
-def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
-    download_directory = Path(getattr(args, "path", config.get_option("client", "download_directory")))
-    verbose = args.verbose or config.get_option("client", "verbose")
-    force = args.force or config.get_option("client", "force")
+def download(anon: AnonPy, args: Namespace, settings: EvalConfig) -> None:
+    client = settings["client"]
 
     for resource in (args.resource or read_file(args.batch_file)):
         with console.status("fetching data...") as _:
@@ -88,21 +123,21 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
             name = preview["name"]
             size = int(preview["size"])
 
-        full_path = download_directory / name
+        full_path = client["download_directory"] / name
 
-        if not force and full_path.exists():
+        if not client["force"] and full_path.exists():
             console.print(f"[bold yellow]WARNING:[/] The file [bold blue]{str(full_path)}[/] already exists")
             prompt = console.input("Proceed with download? [dim][Y/n][/] ")
             if not str2bool(prompt): continue
 
-        anon.download(resource, download_directory, enable_progressbar=verbose, size=size, name=name)
+        anon.download(resource, client["download_directory"], enable_progressbar=client["verbose"], size=size, name=name)
         console.print(f"PATH=[bold blue]{str(full_path)}[/]")
 
         if getattr(args, "checksum", None) is None: continue
         computed_hash = Checksum.compute(path=name, algorithm=MD5)
         computed_checksum = Checksum.hash2string(computed_hash)
 
-        if verbose: console.print(f"MD5={computed_checksum}")
+        if client["verbose"]: console.print(f"MD5={computed_checksum}")
 
         expected_checksum = args.checksum
         corrupt = computed_checksum.lower() != expected_checksum.lower()
@@ -122,9 +157,7 @@ def _start(module_folder: Path, cfg_file: str) -> ArgumentParser:
 
     # Initialize default settings
     cfg_path = module_folder / cfg_file
-
-    if not cfg_path.exists():
-        init_settings(cfg_path)
+    if not cfg_path.exists(): init_config(cfg_path)
 
     return parser
 
@@ -139,19 +172,16 @@ def main() -> None:
     config = ConfigHandler(getattr(args, "config", module_folder / cfg_file))
     config.read()
 
+    settings = eval_config(args, config)
     kwargs = {
-        "api": config.get_option("server", "api"),
-        "endpoint": Endpoint(config.get_option("server", "upload"), config.get_option("server", "download"), config.get_option("server", "preview")),
-        "token": getattr(args, "token", config.get_option("client", "token")),
-        "proxies": getattr(args, "proxies", config.get_option("client", "proxies")),
-        "user_agent": getattr(args, "user_agent", config.get_option("client", "user_agent")) or RequestHandler.build_user_agent(__package__, __version__),
-        "enable_logging": args.logging or config.get_option("client", "enable_logging"),
-    }
+        k: v for k, v in settings["client"].items()
+        if k in ["api", "token", "proxies", "user_agent", "enable_logging"]
+    } | settings["object"] | {"api": settings["server"]["api"]}
 
     provider = AnonPy(**kwargs)
     provider.logger \
         .set_base_path(module_folder) \
-        .with_level(LogLevel(config.get_option("client", "log_level"))) \
+        .with_level(LogLevel(settings["client"]["log_level"])) \
         .add_handler(log_file)
 
     if args.gui:
@@ -160,17 +190,17 @@ def main() -> None:
 
     if args.reset_config:
         config.path.unlink(missing_ok=True)
-        init_settings(config.path)
+        init_config(config.path)
         return
 
     try:
         match args.command:
             case "preview":
-                preview(provider, args, config)
+                preview(provider, args, settings)
             case "upload":
-                upload(provider, args, config)
+                upload(provider, args, settings)
             case "download":
-                download(provider, args, config)
+                download(provider, args, settings)
             case _:
                 # argparse prints the help manual and exits if there are any
                 # errors on parsing, so there's no need to handle this case

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -105,7 +105,7 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
         if verbose: console.print(f"MD5={computed_checksum}")
 
         expected_checksum = args.checksum
-        corrupt = computed_checksum != expected_checksum
+        corrupt = computed_checksum.lower() != expected_checksum.lower()
 
         if corrupt: print_diff(computed_checksum, expected_checksum, console)
 

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -31,6 +31,26 @@ def print_diff(a: str, b: str, console: Console) -> None:
 def copy_to_clipboard(text: str) -> None:
     subprocess.run("clip", input=text, check=True, encoding="utf-8")
 
+def init_settings(cfg_path: Path) -> None:
+    with ConfigHandler(cfg_path) as config_handler:
+        config_handler.add_section("client", settings={
+            "download_directory": Path("~/downloads").expanduser(),
+            "token": None,
+            "user_agent": None,
+            "proxies": None,
+            "enable_logging": False,
+            "log_level": LogLevel.INFO.value,
+            "verbose": True,
+            "force": False,
+        })
+
+        config_handler.add_section("server", settings={
+            "api": "https://pixeldrain.com/api/",
+            "upload": "/file",
+            "download": "/file{}",
+            "preview": "/file/{}/info"
+        })
+
 #endregion
 
 #region commands
@@ -106,24 +126,7 @@ def _start(module_folder: Path, cfg_file: str) -> Tuple[ArgumentParser, Console]
     cfg_path = module_folder / cfg_file
 
     if not cfg_path.exists():
-        with ConfigHandler(cfg_path) as config_handler:
-            config_handler.add_section("client", settings={
-                "download_directory": Path("~/downloads").expanduser(),
-                "token": None,
-                "user_agent": None,
-                "proxies": None,
-                "enable_logging": False,
-                "log_level": LogLevel.INFO.value,
-                "verbose": True,
-                "force": False,
-            })
-
-            config_handler.add_section("server", settings={
-                "api": "https://pixeldrain.com/api/",
-                "upload": "/file",
-                "download": "/file{}",
-                "preview": "/file/{}/info"
-            })
+        init_settings(cfg_path)
 
     return (parser, console)
 
@@ -154,7 +157,13 @@ def main() -> None:
         .add_handler(log_file)
 
     if args.gui:
-        raise NotImplementedError("This feature is not implemented yet, see also: https://github.com/Advanced-Systems/anonpy/discussions/11")
+        console.print("[bold red]ERROR:[/] This feature is not implemented yet, see also: https://github.com/Advanced-Systems/anonpy/discussions/11")
+        return
+
+    if args.reset_config:
+        config.path.unlink(missing_ok=True)
+        init_settings(config.path)
+        return
 
     try:
         match args.command:

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -59,8 +59,9 @@ def preview(anon: AnonPy, args: Namespace, config: ConfigHandler, console: Conso
     verbose = args.verbose or config.get_option("client", "verbose")
 
     for resource in args.resource:
-        preview = anon.preview(resource)
-        console.print(JSON(json.dumps(preview)) if verbose else ",".join(preview.values()))
+        with console.status("fetching data...") as _:
+            preview = anon.preview(resource)
+            console.print(JSON(json.dumps(preview)) if verbose else ",".join(preview.values()))
 
 def upload(anon: AnonPy, args: Namespace, config: ConfigHandler, console: Console) -> None:
     verbose = args.verbose or config.get_option("client", "verbose")

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -49,13 +49,13 @@ def upload(anon: AnonPy, args: Namespace, config: ConfigHandler, console: Consol
         upload = anon.upload(file, progressbar=verbose)
         url = upload.get("url", False) or join_url(anon.api.geturl(), anon.endpoint.download.format(upload["id"]))
         anon.logger.info("Uploaded %s to %s" % (file, url))
+        console.print(f"URL={url}")
 
         if args.clip: copy_to_clipboard(url)
 
         if not verbose: continue
         computed_hash = Checksum.compute(path=file, algorithm=MD5)
         checksum = Checksum.hash2string(computed_hash)
-        console.print(f"URL={url}")
         console.print(f"MD5={checksum}")
 
 def download(anon: AnonPy, args: Namespace, config: ConfigHandler, console: Console) -> None:
@@ -88,8 +88,7 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler, console: Cons
         expected_checksum = args.checksum
         corrupt = computed_checksum != expected_checksum
 
-        if not corrupt: continue
-        print_diff(computed_checksum, expected_checksum, console)
+        if corrupt: print_diff(computed_checksum, expected_checksum, console)
 
 #endregion
 

--- a/src/anonpy/__main__.py
+++ b/src/anonpy/__main__.py
@@ -66,7 +66,7 @@ def upload(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
 
     for file in args.file:
         upload = anon.upload(file, enable_progressbar=verbose)
-        url = upload.get("url", False) or join_url(anon.api.geturl(), anon.endpoint.download.format(upload["id"]))
+        url = upload["url"]
         anon.logger.info("Uploaded %s to %s" % (file, url))
         console.print(f"URL={url}")
 
@@ -83,18 +83,10 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
     force = args.force or config.get_option("client", "force")
 
     for resource in (args.resource or read_file(args.batch_file)):
-        name = None
-        size = None
-
         with console.status("fetching data...") as _:
             preview = anon.preview(resource)
-            name = preview.get("name")
-            size = preview.get("size")
-
-        if name is None or size is None:
-            console.print("[bold red]ERROR:[/] unable to determine properties from preview response, aborting download", style="bold red")
-            anon.logger.error("ERROR: resource %s responded with %s during download" % (args.resource, str(preview)), stacklevel=2)
-            continue
+            name = preview["name"]
+            size = int(preview["size"])
 
         full_path = download_directory / name
 
@@ -103,7 +95,7 @@ def download(anon: AnonPy, args: Namespace, config: ConfigHandler) -> None:
             prompt = console.input("Proceed with download? [dim][Y/n][/] ")
             if not str2bool(prompt): continue
 
-        anon.download(resource, download_directory, enable_progressbar=verbose, size=int(size), name=name)
+        anon.download(resource, download_directory, enable_progressbar=verbose, size=size, name=name)
         console.print(f"PATH=[bold blue]{str(full_path)}[/]")
 
         if getattr(args, "checksum", None) is None: continue

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Self, Union, overload
 
 from .endpoint import Endpoint
 from .internals import LogHandler, LogLevel, RequestHandler, Timeout, __package__, get_progress_bar, join_url, truncate
+from .server_response import ServerResponse
 
 
 class AnonPy(RequestHandler):
@@ -80,7 +81,7 @@ class AnonPy(RequestHandler):
         self.enable_logging = enable_logging
         self.logger = LogHandler(level=LogLevel.INFO)
 
-    def upload(self: Self, path: Union[str, Path], enable_progressbar: bool=False) -> Dict:
+    def upload(self: Self, path: Union[str, Path], enable_progressbar: bool=False) -> ServerResponse:
         """
         Upload a file. Set `enable_progressbar` to `True` to enable a terminal
         progress indicator.
@@ -115,13 +116,13 @@ class AnonPy(RequestHandler):
 
         self.logger.info("Upload %s to %s", name, url, hide=not self.enable_logging, stacklevel=2)
 
-        return {
-            "name": name,
-            "folder": path,
-            "size": size,
-            "resource": resource,
-            "url": url,
-        }
+        return ServerResponse(
+            name,
+            path,
+            size,
+            resource,
+            url,
+        )
 
     def preview(self: Self, resource: str) -> Dict:
         """
@@ -164,7 +165,7 @@ class AnonPy(RequestHandler):
             enable_progressbar: bool=False,
             size: Optional[int]=None,
             name: Optional[str]=None,
-        ) -> Dict:
+        ) -> ServerResponse:
         if enable_progressbar and (size is None or name is None):
             raise TypeError("invalid combination of arguments")
 
@@ -187,10 +188,10 @@ class AnonPy(RequestHandler):
 
         self.logger.info("Download %s to %s", url, full_path, hide=not self.enable_logging, stacklevel=2)
 
-        return {
-            "name": name,
-            "folder": path,
-            "size": size,
-            "resource": resource,
-            "url": url,
-        }
+        return ServerResponse(
+            name,
+            path,
+            size,
+            resource,
+            url,
+        )

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -106,7 +106,7 @@ class AnonPy(RequestHandler):
                     files={"file": CallbackIOWrapper(tqdm_handler.update, file_handler, "read")}
                 )
 
-                self.logger.info("Download: %s", file, hide=not self.enable_logging, stacklevel=2)
+                self.logger.info("Upload: %s", file, hide=not self.enable_logging, stacklevel=2)
                 return response.json()
 
     def preview(self: Self, resource: str) -> Dict:
@@ -145,5 +145,5 @@ class AnonPy(RequestHandler):
                         tqdm_handler.update(len(chunk))
                         file_handler.write(chunk)
 
-        self.logger.info("Upload: %s", url, hide=not self.enable_logging, stacklevel=2)
+        self.logger.info("Download: %s", url, hide=not self.enable_logging, stacklevel=2)
         return preview

--- a/src/anonpy/anonpy.py
+++ b/src/anonpy/anonpy.py
@@ -88,7 +88,6 @@ class AnonPy(RequestHandler):
         MB = 1_048_576
         name = Path(path).name
         size = os.stat(path).st_size
-        # response = None
         chunk_size = min(1*MB, size // 2)
 
         with get_progress_bar() as progress:
@@ -114,7 +113,7 @@ class AnonPy(RequestHandler):
             relative_url = self.endpoint.download.format(resource)
             url = join_url(self.api.geturl(), relative_url)
 
-        self.logger.info("Upload: %s to %s", name, url, hide=not self.enable_logging, stacklevel=2)
+        self.logger.info("Upload %s to %s", name, url, hide=not self.enable_logging, stacklevel=2)
 
         return {
             "name": name,

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -23,6 +23,7 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     upload_parser = subparser.add_parser("upload", help="upload a file")
     upload_parser.add_argument("-f", "--file", nargs="+", type=Path, help="one or more files to upload.", required=True)
     upload_parser.add_argument("-c", "--clip", default=False, action="store_true", help="copy download URL to clipboard")
+    upload_parser.add_argument("--algorithm", type=str, default=SUPPRESS, help="checksum algorithm")
 
     preview_parser = subparser.add_parser("preview", help="read meta data from a remote file")
     preview_parser.add_argument("-r", "--resource", nargs="+", type=str, help="one or more resources to preview", required=True)
@@ -34,5 +35,6 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     download_parser.add_argument("-p", "--path", type=Path, default=SUPPRESS, help="download directory (CWD by default)")
     download_parser.add_argument("-f", "--force", default=False, action="store_true", help="overwrite duplicates, if any")
     download_parser.add_argument("--checksum", type=str, default=SUPPRESS, help="expected MD5 checksum value for integrity test")
+    download_parser.add_argument("--hash", type=str, default=SUPPRESS, help="checksum algorithm")
 
     return parser

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -15,7 +15,7 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     parser.add_argument("-u", "--user-agent", type=str, default=SUPPRESS, help="set custom user-agent")
     parser.add_argument("-p", "--proxies", type=str, default=SUPPRESS, help="set HTTP/HTTPS proxies")
     parser.add_argument("-c", "--config", type=Path, default=SUPPRESS, help="path to config file")
-    parser.add_argument("-g", "--gui", default=True, action="store_true", help="launch the GUI frontend")
+    parser.add_argument("-g", "--gui", default=False, action="store_true", help="launch the GUI frontend")
 
     subparser = parser.add_subparsers(dest="command")
     upload_parser = subparser.add_parser("upload", help="upload a file")

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -30,5 +30,6 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     download_urls_group.add_argument("-b", "--batch-file", type=Path, nargs="?", help="file containing resources to download")
     download_parser.add_argument("-p", "--path", type=Path, default=SUPPRESS, help="download directory (CWD by default)")
     download_parser.add_argument("-f", "--force", default=False, action="store_true", help="overwrite duplicates, if any")
+    download_parser.add_argument("-c", "--checksum", type=str, default=SUPPRESS, help="expected MD5 checksum value for integrity test")
 
     return parser

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -27,8 +27,8 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     download_parser = subparser.add_parser("download", help="download a file")
     download_urls_group = download_parser.add_mutually_exclusive_group(required=True)
     download_urls_group.add_argument("-r", "--resource", nargs="*", type=str, help="one or more resources to download")
-    download_urls_group.add_argument("-f", "--batch-file", type=Path, nargs="?", help="file containing resources to download")
+    download_urls_group.add_argument("-b", "--batch-file", type=Path, nargs="?", help="file containing resources to download")
     download_parser.add_argument("-p", "--path", type=Path, default=SUPPRESS, help="download directory (CWD by default)")
-    download_parser.add_argument("-c", "--check", default=False, action="store_true", help="check for duplicates")
+    download_parser.add_argument("-f", "--force", default=False, action="store_true", help="overwrite duplicates, if any")
 
     return parser

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -15,6 +15,7 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     parser.add_argument("-u", "--user-agent", type=str, default=SUPPRESS, help="set custom user-agent")
     parser.add_argument("-p", "--proxies", type=str, default=SUPPRESS, help="set HTTP/HTTPS proxies")
     parser.add_argument("-c", "--config", type=Path, default=SUPPRESS, help="path to config file")
+    parser.add_argument("-g", "--gui", default=True, action="store_true", help="launch the GUI frontend")
 
     subparser = parser.add_subparsers(dest="command")
     upload_parser = subparser.add_parser("upload", help="upload a file")

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 
-from argparse import ArgumentParser, SUPPRESS
+from argparse import ArgumentParser, HelpFormatter, SUPPRESS
 from pathlib import Path
 
 def build_parser(package_name: str, version: str, description: str, epilog: str) -> ArgumentParser:
-    parser = ArgumentParser(prog=package_name, description=description, epilog=epilog)
+    formatter = lambda prog: HelpFormatter(prog,max_help_position=52)
+    parser = ArgumentParser(prog=package_name, description=description, epilog=epilog, formatter_class=formatter)
     parser._positionals.title = "Commands"
     parser._optionals.title = "Arguments"
 
     parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {version}")
-    parser.add_argument('-V', '--verbose', default=True, action='store_true', help="increase output verbosity")
-    parser.add_argument("-l", "--logging", default=False, action="store_true", help="log request history")
-    parser.add_argument("-t", "--token", type=str, default=SUPPRESS, help="set API token")
-    parser.add_argument("-u", "--user-agent", type=str, default=SUPPRESS, help="set custom user-agent")
-    parser.add_argument("-p", "--proxies", type=str, default=SUPPRESS, help="set HTTP/HTTPS proxies")
-    parser.add_argument("-c", "--config", type=Path, default=SUPPRESS, help="path to config file")
-    parser.add_argument("-g", "--gui", default=False, action="store_true", help="launch the GUI frontend")
+    parser.add_argument("--verbose", default=True, action="store_true", help="increase output verbosity")
+    parser.add_argument("--logging", default=False, action="store_true", help="log request history")
+    parser.add_argument("--token", type=str, default=SUPPRESS, help="set API token")
+    parser.add_argument("--user-agent", type=str, default=SUPPRESS, help="set custom user-agent")
+    parser.add_argument("--proxies", type=str, default=SUPPRESS, help="set HTTP/HTTPS proxies")
+    parser.add_argument("--config", type=Path, default=SUPPRESS, help="path to config file")
+    parser.add_argument("--gui", default=False, action="store_true", help="launch the GUI frontend")
+    parser.add_argument("--reset-config", default=False, action="store_true", help="reset default config file")
 
     subparser = parser.add_subparsers(dest="command")
     upload_parser = subparser.add_parser("upload", help="upload a file")
@@ -28,9 +30,9 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     download_parser = subparser.add_parser("download", help="download a file")
     download_urls_group = download_parser.add_mutually_exclusive_group(required=True)
     download_urls_group.add_argument("-r", "--resource", nargs="*", type=str, help="one or more resources to download")
-    download_urls_group.add_argument("-b", "--batch-file", type=Path, nargs="?", help="file containing resources to download")
+    download_urls_group.add_argument("--batch-file", type=Path, nargs="?", help="file containing resources to download")
     download_parser.add_argument("-p", "--path", type=Path, default=SUPPRESS, help="download directory (CWD by default)")
     download_parser.add_argument("-f", "--force", default=False, action="store_true", help="overwrite duplicates, if any")
-    download_parser.add_argument("-c", "--checksum", type=str, default=SUPPRESS, help="expected MD5 checksum value for integrity test")
+    download_parser.add_argument("--checksum", type=str, default=SUPPRESS, help="expected MD5 checksum value for integrity test")
 
     return parser

--- a/src/anonpy/cli.py
+++ b/src/anonpy/cli.py
@@ -20,6 +20,7 @@ def build_parser(package_name: str, version: str, description: str, epilog: str)
     subparser = parser.add_subparsers(dest="command")
     upload_parser = subparser.add_parser("upload", help="upload a file")
     upload_parser.add_argument("-f", "--file", nargs="+", type=Path, help="one or more files to upload.", required=True)
+    upload_parser.add_argument("-c", "--clip", default=False, action="store_true", help="copy download URL to clipboard")
 
     preview_parser = subparser.add_parser("preview", help="read meta data from a remote file")
     preview_parser.add_argument("-r", "--resource", nargs="+", type=str, help="one or more resources to preview", required=True)

--- a/src/anonpy/internals/__init__.py
+++ b/src/anonpy/internals/__init__.py
@@ -10,11 +10,13 @@ from .timeout import Timeout
 from .utils import (
     console,
     convert,
+    copy_to_clipboard,
     get_progress_bar,
     get_resource_path,
     get_while,
     ignore_warnings,
     join_url,
+    print_diff,
     read_file,
     str2bool,
     truncate,

--- a/src/anonpy/internals/__init__.py
+++ b/src/anonpy/internals/__init__.py
@@ -8,15 +8,16 @@ from .log_handler import LogHandler, LogLevel
 from .request_handler import RequestHandler
 from .timeout import Timeout
 from .utils import (
-    _progressbar_options,
     console,
     convert,
+    get_progress_bar,
     get_resource_path,
     get_while,
     ignore_warnings,
     join_url,
     read_file,
     str2bool,
+    truncate,
     unique
 )
 

--- a/src/anonpy/internals/__init__.py
+++ b/src/anonpy/internals/__init__.py
@@ -9,6 +9,7 @@ from .request_handler import RequestHandler
 from .timeout import Timeout
 from .utils import (
     _progressbar_options,
+    console,
     convert,
     get_resource_path,
     get_while,

--- a/src/anonpy/internals/config_handler.py
+++ b/src/anonpy/internals/config_handler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from configparser import ConfigParser
+from configparser import ConfigParser, NoOptionError, NoSectionError
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Self, Type, Union
@@ -81,13 +81,19 @@ class ConfigHandler:
         """
         Return a list of option names for the given section name.
         """
-        return self.__config.options(section)
+        try:
+            return self.__config.options(section)
+        except NoSectionError:
+            return []
 
     def get_option(self: Self, section: str, option: str) -> Optional[Any]:
         """
         Get the value of an option for a given section.
         """
-        return convert(self.__config.get(section, option))
+        try:
+            return convert(self.__config.get(section, option))
+        except NoOptionError:
+            return None
 
     def set_option(self: Self, section: str, option: str, value: Optional[Any]) -> None:
         """

--- a/src/anonpy/internals/config_handler.py
+++ b/src/anonpy/internals/config_handler.py
@@ -86,14 +86,14 @@ class ConfigHandler:
         except NoSectionError:
             return []
 
-    def get_option(self: Self, section: str, option: str) -> Optional[Any]:
+    def get_option(self: Self, section: str, option: str, default: Optional[Any]=None) -> Optional[Any]:
         """
         Get the value of an option for a given section.
         """
         try:
             return convert(self.__config.get(section, option))
         except NoOptionError:
-            return None
+            return default
 
     def set_option(self: Self, section: str, option: str, value: Optional[Any]) -> None:
         """

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -108,7 +108,7 @@ class LogHandler:
             case ".json":
                 self.formatter = JsonFormatter(fmt_dict=layout or default_structured_layout)
             case "rich_console":
-                rich_handler = RichHandler()
+                rich_handler = RichHandler(rich_tracebacks=True)
                 self.handlers["rich_console"] = rich_handler
                 self.__logger.addHandler(rich_handler)
                 return self

--- a/src/anonpy/internals/log_handler.py
+++ b/src/anonpy/internals/log_handler.py
@@ -6,7 +6,9 @@ import sys
 from enum import Enum, unique
 from logging import FileHandler, Formatter, StreamHandler, getLogger
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Self, TypedDict, Union, Unpack
+from typing import Any, Dict, List, Literal, Mapping, Optional, Self, Tuple, TypedDict, Union, Unpack
+
+from rich.logging import RichHandler
 
 from .csv_formatter import CsvFormatter
 from .json_formatter import JsonFormatter
@@ -79,7 +81,7 @@ class LogHandler:
 
     def add_handler(
             self: Self,
-            name: Optional[Union[str, Path]]=None,
+            name: Tuple[Union[str, Path], Literal["console", "rich_console"]]=None,
             layout: Optional[Union[str, Dict[str,str]]]=None
         ) -> Self:
         """
@@ -88,7 +90,7 @@ class LogHandler:
 
         Note that plain log files or console logs should define the layout as a `str`.
         """
-        target = Path(name).suffix if name is not None else "console"
+        target = Path(name).suffix if name not in ("console", "rich_console") else name
         default_layout = "%(asctime)s [%(levelname)s] %(pathname)s@%(lineno)d - %(message)s"
         default_structured_layout = {
             "timestamp": "asctime",
@@ -105,6 +107,11 @@ class LogHandler:
                 self.formatter = CsvFormatter(fmt_dict=layout or default_structured_layout)
             case ".json":
                 self.formatter = JsonFormatter(fmt_dict=layout or default_structured_layout)
+            case "rich_console":
+                rich_handler = RichHandler()
+                self.handlers["rich_console"] = rich_handler
+                self.__logger.addHandler(rich_handler)
+                return self
             case "console":
                 console = StreamHandler(sys.stdout)
                 self.formatter = Formatter(default_layout or layout)

--- a/src/anonpy/internals/request_handler.py
+++ b/src/anonpy/internals/request_handler.py
@@ -153,7 +153,7 @@ class RequestHandler:
         session.headers.update({"User-Agent": self.user_agent})
         return session
 
-    def _get(self: Self, endpoint: str, **kwargs) -> Response:
+    def _get(self: Self, relative_path: str, **kwargs) -> Response:
         """
         Return the GET request, encoded in `utf-8` by default. This method will
         add proxies to this session on the fly if urllib is able to pick up the
@@ -163,7 +163,7 @@ class RequestHandler:
         code.
         """
         response = self._session.get(
-            url=join_url(self.api.geturl(), endpoint),
+            url=join_url(self.api.geturl(), relative_path),
             timeout=self.timeout,
             proxies=self.proxies,
             **kwargs
@@ -171,24 +171,24 @@ class RequestHandler:
         response.encoding = self.encoding
         return response
 
-    def _post(self, endpoint: str, **kwargs) -> Response:
+    def _post(self, relative_path: str, **kwargs) -> Response:
         """
         Send a POST request and return a `Response` object as a result.
         """
         return self._session.post(
-            url=join_url(self.api.geturl(), endpoint),
+            url=join_url(self.api.geturl(), relative_path),
             timeout=self.timeout,
             proxies=self.proxies,
             verify=True,
             **kwargs
         )
 
-    def _put(self, endpoint: str, **kwargs) -> Response:
+    def _put(self, relative_path: str, **kwargs) -> Response:
         """
         Send a PUT request and return a `Response` object as a result.
         """
         return self._session.put(
-            url=join_url(self.api.geturl(), endpoint),
+            url=join_url(self.api.geturl(), relative_path),
             timeout=self.timeout,
             proxies=self.proxies,
             verify=True,

--- a/src/anonpy/internals/utils.py
+++ b/src/anonpy/internals/utils.py
@@ -59,7 +59,7 @@ def join_url(url: str, *paths) -> str:
     """
     Join a relative list of paths with a URL.
     """
-    return functools.reduce(lambda u, p: f"{u}/{p}", [url, *paths])
+    return functools.reduce(lambda u, p: f"{u.rstrip("/")}/{p.lstrip("/")}", [url, *paths])
 
 def get_while(dict_: Dict, default: Any, *keys: str) -> Any:
     """

--- a/src/anonpy/internals/utils.py
+++ b/src/anonpy/internals/utils.py
@@ -8,6 +8,9 @@ import warnings
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
 
+from rich.console import Console
+
+console = Console(color_system="256")
 
 def convert(value: str) -> Optional[Any]:
     """

--- a/src/anonpy/internals/utils.py
+++ b/src/anonpy/internals/utils.py
@@ -4,11 +4,13 @@ import ast
 import functools
 import os
 import platform
+import textwrap
 import warnings
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
 
 from rich.console import Console
+from rich.progress import BarColumn, DownloadColumn, Progress, TextColumn, TimeRemainingColumn, TransferSpeedColumn
 
 console = Console(color_system="256")
 
@@ -89,6 +91,15 @@ def str2bool(val: str) -> bool:
     """
     return val.lower() in ("yes", "y", "true", "t", "1", "on", "")
 
+def truncate(text: str, width: int, placeholder: str="...") -> str:
+    """
+    Reduce the given text with a placeholder to fit in the given width.
+    """
+    stripped = text.strip()
+    if len(stripped) <= width: return stripped
+
+    return textwrap.shorten(stripped, width, placeholder=placeholder)
+
 def read_file(path: Union[str, Path]) -> Iterator[str]:
     """
     Open a text file and returns its right-striped content line by line, except
@@ -97,26 +108,19 @@ def read_file(path: Union[str, Path]) -> Iterator[str]:
     with open(path, mode="r", encoding="utf-8") as file_handler:
         yield (line.rstrip() for line in file_handler.readlines() if line[0] != "#")
 
-def _progressbar_options(
-        iterable: Iterable,
-        desc: str,
-        unit: str,
-        color: str="\033[32m",
-        char: str="\u25CB",
-        total: int=None,
-        disable: bool=False
-    ) -> Dict:
+def get_progress_bar() -> Progress:
     """
-    Return custom optional arguments for `tqdm` progressbars.
+    Return a `rich` progress bar. This configuration expects a `name` property
+    to be initialized with the `add_task` method.
     """
-    return {
-        "iterable": iterable,
-        "bar_format": "{l_bar}%s{bar}%s{r_bar}" % (color, "\033[0m"),
-        "ascii": char.rjust(9, " "),
-        "desc": desc,
-        "unit": unit.rjust(1, " "),
-        "unit_scale": True,
-        "unit_divisor": 1024,
-        "total": len(iterable) if total is None else total,
-        "disable": not disable
-    }
+    return Progress(
+        TextColumn("[bold blue]{task.fields[name]}", justify="right"),
+        BarColumn(bar_width=None),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        "•",
+        DownloadColumn(),
+        "•",
+        TransferSpeedColumn(),
+        "•",
+        TimeRemainingColumn(),
+    )

--- a/src/anonpy/internals/utils.py
+++ b/src/anonpy/internals/utils.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import ast
+import difflib
 import functools
 import os
 import platform
+import subprocess
 import textwrap
 import warnings
 from pathlib import Path
@@ -107,6 +109,23 @@ def read_file(path: Union[str, Path]) -> Iterator[str]:
     """
     with open(path, mode="r", encoding="utf-8") as file_handler:
         yield (line.rstrip() for line in file_handler.readlines() if line[0] != "#")
+
+def print_diff(a: str, b: str, console: Console) -> None:
+    """
+    Print difference between two strings to `console`.
+    """
+    diff = difflib.ndiff(
+        f"{a}\n".splitlines(keepends=True),
+        f"{b}\n".splitlines(keepends=True)
+    )
+
+    console.print("".join(diff), end="")
+
+def copy_to_clipboard(text: str) -> None:
+    """
+    Copy the passed text to clipboard.
+    """
+    subprocess.run("clip", input=text, check=True, encoding="utf-8")
 
 def get_progress_bar() -> Progress:
     """

--- a/src/anonpy/server_response.py
+++ b/src/anonpy/server_response.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ServerResponse:
+    name: str
+    folder: Path
+    size: int
+    resource: str
+    url: str


### PR DESCRIPTION
## Description

This feature request serves as a collection of small TODOs related to the anonpy CLI.

## Requirements

- [x] add a --gui flag and raise NotImplementedError("TODO")
- [x] add a --clip flag to the download and upload command that, when enabled, copies the URL to clipboard
- [x] ~~add a --checksum flag for switching between MD5, SHA1 or SHA256~~
- [x] ~~add a --provider flag for setting the target server, by using built-in providers implemented in the providers namespace~~
- [x] add a `--algorithm` flag to the CLI and settings file
- [x] update docs


## Remarks

- If the download or upload method are run with the --verbose flag, anonpy will automatically return the default checksum (MD5).
- The default checksum should also be configurable via the ConfigHandler class (see also: https://github.com/Advanced-Systems/anonpy/issues/13)

---

The following changes were made to the original specification:

- instead of specifying a `--provider` flag, use the `anonpy.ini` file for configuring the requested API
- use the `--checksum` flag for passing the expected checksum